### PR TITLE
Add support for zlib compression & DefaultCodec

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -19,7 +19,6 @@ import (
 var (
 	Codecs map[string]Codec = map[string]Codec{
 		"org.apache.hadoop.io.compress.DefaultCodec": &ZlibCodec{},
-		"org.apache.hadoop.io.compress.ZlibCodec":    &ZlibCodec{},
 		"org.apache.hadoop.io.compress.Lz4Codec":     &Lz4Codec{},
 		"org.apache.hadoop.io.compress.BZip2Codec":   &Bzip2Codec{},
 	}


### PR DESCRIPTION
Hi thanks for writing go-hadoop-io!  I added a small change to add support for the "org.apache.hadoop.io.compress.DefaultCodec" compression type and based it on your bzip2 reader as well as on this [python-hadoop package's sequencefile reader ZlibCodec module](https://github.com/matteobertozzi/Hadoop/blob/master/python-hadoop/hadoop/io/compress/ZlibCodec.py).

The Java implementation is here: https://github.com/apache/hadoop/blob/master/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/DefaultCodec.java
